### PR TITLE
Allow empty rt schedule

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cometr
 Title: R Support for 'comet'
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/api.R
+++ b/R/api.R
@@ -87,6 +87,9 @@ endpoint_nimue_run <- function() {
 
 target_nimue_run <- function(pars) {
   pars <- jsonlite::fromJSON(pars)
+  if (length(pars$rt) == 0) {
+    pars$rt <- data.frame(start = numeric(), value = numeric())
+  }
   res <- nimue_run(pars)
   jsonlite::toJSON(res, dataframe = "rows", na = "null", null = "null")
 }

--- a/tests/testthat/test-api.R
+++ b/tests/testthat/test-api.R
@@ -58,3 +58,28 @@ test_that("run", {
   expect_equal(res_api$headers[["X-Porcelain-Validated"]], "true")
   expect_equal(res_api$body, res_endpoint$body)
 })
+
+
+test_that("allow empty rt schedule", {
+  endpoint <- endpoint_nimue_run()
+
+  body <- paste(readLines("nimue-run-example.json"), collapse = "\n")
+  dat <- jsonlite::parse_json(body)
+  dat$rt <- list()
+  body <- jsonlite::toJSON(dat, auto_unbox = TRUE, null = "null")
+
+  res_target <- endpoint$target(body)
+  expect_s3_class(res_target, "json")
+
+  res_endpoint <- endpoint$run(body)
+  expect_true(res_endpoint$validated)
+  expect_equal(res_endpoint$data, res_target)
+
+  api <- build_api(validate = TRUE)
+  res_api <- suppressMessages(api$request("POST", "/nimue/run", body = body))
+
+  expect_equal(res_api$status, 200L)
+  expect_equal(res_api$headers[["Content-Type"]], "application/json")
+  expect_equal(res_api$headers[["X-Porcelain-Validated"]], "true")
+  expect_equal(res_api$body, res_endpoint$body)
+})


### PR DESCRIPTION
This PR allows an rt of `[]` to be accepted by translating it to a zero-length data.frame. nimue seems ok with being passed zero-length numeric vectors for inputs here, but not `NULL`